### PR TITLE
reduce heap usage - intern strings, use int instead of InetAddress

### DIFF
--- a/src/main/java/in/ankushs/dbip/importer/ResourceImporter.java
+++ b/src/main/java/in/ankushs/dbip/importer/ResourceImporter.java
@@ -1,5 +1,7 @@
 package in.ankushs.dbip.importer;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,6 +38,8 @@ public final class ResourceImporter {
 	private final CsvParser csvParser =  CsvParserImpl.getInstance();
 	private static ResourceImporter instance = null;
 
+	private Interner<String> interner = Interners.newWeakInterner();
+
 	private ResourceImporter(){}
 	
 	public static ResourceImporter getInstance() {
@@ -70,9 +74,12 @@ public final class ResourceImporter {
 			while ((line = reader.readLine()) != null) {
 				i++;
 				final String[] array = csvParser.parseRecord(line);
-				final GeoAttributes geoAttributes = new GeoAttributesImpl.Builder().withCity(array[4])
-						.withCountry(CountryResolver.resolveToFullName(array[2])).withProvince(array[3])
-						.withEndIp(InetAddresses.forString(array[1])).withStartIp(InetAddresses.forString(array[0]))
+				final GeoAttributes geoAttributes = new GeoAttributesImpl.Builder()
+						.withCity(interner.intern(array[4]))
+						.withCountry(CountryResolver.resolveToFullName(array[2]))
+						.withProvince(interner.intern(array[3]))
+						.withEndIp(InetAddresses.coerceToInteger(InetAddresses.forString(array[1])))
+						.withStartIp(InetAddresses.coerceToInteger(InetAddresses.forString(array[0])))
 						.build();
 				repository.save(geoAttributes);
 				if (i % 100000 == 0) {

--- a/src/main/java/in/ankushs/dbip/model/GeoAttributes.java
+++ b/src/main/java/in/ankushs/dbip/model/GeoAttributes.java
@@ -5,7 +5,7 @@ import java.net.InetAddress;
 import in.ankushs.dbip.api.GeoEntity;
 
 public interface GeoAttributes {
-	InetAddress getStartIp();
-	InetAddress getEndIp();
+	int getStartIp();
+	int getEndIp();
 	GeoEntity getGeoEntity();
 }

--- a/src/main/java/in/ankushs/dbip/model/GeoAttributesImpl.java
+++ b/src/main/java/in/ankushs/dbip/model/GeoAttributesImpl.java
@@ -5,8 +5,8 @@ import java.net.InetAddress;
 import in.ankushs.dbip.api.GeoEntity;
 
 public final class GeoAttributesImpl implements GeoAttributes {
-	private final InetAddress startIp;
-	private final InetAddress endIp;
+	private final int startIp;
+	private final int endIp;
 	private final String city;
 	private final String country;
 	private final String province ;
@@ -20,18 +20,18 @@ public final class GeoAttributesImpl implements GeoAttributes {
 	}
 	
 	public static class Builder{
-		private  InetAddress startIp;
-		private  InetAddress endIp;
+		private  int startIp;
+		private  int endIp;
 		private  String city;
 		private  String country;
 		private  String province ;
 		
-		public Builder withStartIp(final InetAddress startIp){
+		public Builder withStartIp(final int startIp){
 			this.startIp = startIp;
 			return this;
 		}
 		
-		public Builder withEndIp(final InetAddress endIp){
+		public Builder withEndIp(final int endIp){
 			this.endIp = endIp;
 			return this;
 		}
@@ -60,12 +60,12 @@ public final class GeoAttributesImpl implements GeoAttributes {
 	}
 
 	@Override
-	public InetAddress getStartIp() {
+	public int getStartIp() {
 		return startIp;
 	}
 
 	@Override
-	public InetAddress getEndIp() {
+	public int getEndIp() {
 		return endIp;
 	}
 

--- a/src/main/java/in/ankushs/dbip/repository/JavaMapDbIpRepositoryImpl.java
+++ b/src/main/java/in/ankushs/dbip/repository/JavaMapDbIpRepositoryImpl.java
@@ -52,7 +52,7 @@ public final class JavaMapDbIpRepositoryImpl implements DbIpRepository {
 	@Override
 	public void save(final GeoAttributes geoAttributes) {
 		PreConditions.checkNull(geoAttributes, "geoAttributes must not be null");
-		final Integer startIpNum = InetAddresses.coerceToInteger(geoAttributes.getStartIp());
+		final Integer startIpNum = geoAttributes.getStartIp();
 		final GeoEntity geoEntity = geoAttributes.getGeoEntity();
 		repository.put(startIpNum,geoEntity);
 	}

--- a/src/test/groovy/in/ankushs/dbip/DbIpClientSpec.groovy
+++ b/src/test/groovy/in/ankushs/dbip/DbIpClientSpec.groovy
@@ -12,6 +12,7 @@ class DbIpClientSpec extends BaseSpec {
 	
 	def "Pass a valid Ip.All should work fine"(){
 		when : "Call the client"
+			def ip = "216.159.232.248"
 			def client = new DbIpClient(file)
 			GeoEntity geoEntity = client.lookup(ip)
 		then : "Should return some info.No exception thrown"


### PR DESCRIPTION
Changes:
- Intern strings in `ResourceImporter`
- Use `int` instead of  `InetAddress` in `GeoAttributes`
- Fix failing test in `DbIpClientSpec`

Heap usage:
- default: 2.4G
- with string interning: 1.7G (the percent of heap space used by strings went from 28% to 0.2%)
- with string interning and using `int` instead of `InetAddress` in `GeoAttributes`: 1.2G